### PR TITLE
Add TTS audio and vocabulary enrichment features

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import os, json, uuid, yaml
 from flask import Flask, send_from_directory
 from services.llm_service import LLMClient
 from services.image_service import ImageFetcher
+from services.tts_service import TTSClient
 
 def create_app():
     BASE = os.path.dirname(__file__)
@@ -36,6 +37,10 @@ def create_app():
     app.config["IMG_FETCHER"] = ImageFetcher(
         api_key=app.config["G_CSE_KEY"],
         cx=app.config["G_CSE_CX"]
+    )
+    app.config["TTS_CLIENT"] = TTSClient(
+        api_key=app.config["OPENAI_KEY"],
+        model="gpt-4o-mini-tts"
     )
 
     # ---- Active session store (in-memory) ----

--- a/routes/vocab_test.py
+++ b/routes/vocab_test.py
@@ -84,7 +84,7 @@ def vocab_save_selection():
         "id": str(uuid.uuid4()), "word": word.capitalize(),
         "status": "raw", "origin": "manual",
         "pos": "", "meaning_vi": "", "usage": "", "phonetic": "",
-        "image_url": None,
+        "image_url": None, "audio_url": None,
         "created_at": now, "updated_at": now,
         "memory_label": "", "stats": {"correct": 0, "wrong": 0}
     }
@@ -92,11 +92,18 @@ def vocab_save_selection():
     if bool(payload.get("enrich_now")):
         llm: LLMClient = current_app.config["LLM_CLIENT"]
         img = current_app.config["IMG_FETCHER"]
+        tts = current_app.config["TTS_CLIENT"]
         try:
             desc = llm.describe_word(card["word"]) if current_app.config["OPENAI_KEY"] else {}
             card["pos"] = desc.get("pos",""); card["meaning_vi"] = desc.get("meaning_vi","")
             card["usage"] = desc.get("usage",""); card["phonetic"] = desc.get("phonetic","")
             card["image_url"] = img.fetch(card["word"]) if (current_app.config["G_CSE_KEY"] and current_app.config["G_CSE_CX"]) else None
+            if current_app.config["OPENAI_KEY"]:
+                audio_dir = __import__("os").path.join(current_app.config["CARDS_DIR"], "audio")
+                filename = f"{card['id']}.mp3"
+                full = __import__("os").path.join(audio_dir, filename)
+                if tts.synthesize_to_file(card["word"], full):
+                    card["audio_url"] = f"/data/cards/audio/{filename}"
             card["status"] = "enrich"; card["updated_at"] = _iso(_utcnow())
         except Exception:
             pass
@@ -104,6 +111,59 @@ def vocab_save_selection():
     data["cards"].append(card)
     save_cards(data)
     return jsonify({"ok": True, "message": "Đã lưu từ", "card": card})
+
+@bp.post("/vocab/fill_missing/<id_or_word>")
+def vocab_fill_missing(id_or_word: str):
+    """Fill missing fields (pos, meaning_vi, usage, phonetic, image, audio) for a card."""
+    ensure_card_ids()
+    key = (id_or_word or "").strip()
+    data = load_cards()
+    target = None
+    for c in data["cards"]:
+        if str(c.get("id")) == key or str(c.get("word", "")).lower() == key.lower():
+            target = c
+            break
+    if not target:
+        return jsonify({"error": "not found"}), 404
+
+    llm: LLMClient = current_app.config["LLM_CLIENT"]
+    img: ImageFetcher = current_app.config["IMG_FETCHER"]
+    tts = current_app.config["TTS_CLIENT"]
+    changed = False
+
+    if current_app.config["OPENAI_KEY"] and (not target.get("pos") or not target.get("meaning_vi") or not target.get("usage") or not target.get("phonetic")):
+        try:
+            desc = llm.describe_word(target["word"])
+            if not target.get("pos"): target["pos"] = desc.get("pos", "")
+            if not target.get("meaning_vi"): target["meaning_vi"] = desc.get("meaning_vi", "")
+            if not target.get("usage"): target["usage"] = desc.get("usage", "")
+            if not target.get("phonetic"): target["phonetic"] = desc.get("phonetic", "")
+            changed = True
+        except Exception:
+            pass
+
+    if (not target.get("image_url")) and current_app.config["G_CSE_KEY"] and current_app.config["G_CSE_CX"]:
+        try:
+            target["image_url"] = img.fetch(target["word"])
+            changed = True
+        except Exception:
+            pass
+
+    if (not target.get("audio_url")) and current_app.config["OPENAI_KEY"]:
+        audio_dir = __import__("os").path.join(current_app.config["CARDS_DIR"], "audio")
+        filename = f"{target['id']}.mp3"
+        full = __import__("os").path.join(audio_dir, filename)
+        if tts.synthesize_to_file(target["word"], full):
+            target["audio_url"] = f"/data/cards/audio/{filename}"
+            changed = True
+
+    if changed:
+        if (target.get("status") or "").lower() == "raw":
+            target["status"] = "enrich"
+        target["updated_at"] = _iso(_utcnow())
+        save_cards(data)
+
+    return jsonify({"card": target, "updated": changed})
 
 @bp.post("/vocab/enrich_all")
 def vocab_enrich_all():
@@ -117,6 +177,7 @@ def vocab_enrich_all():
     data = load_cards()
     llm: LLMClient = current_app.config["LLM_CLIENT"]
     img: ImageFetcher = current_app.config["IMG_FETCHER"]
+    tts = current_app.config["TTS_CLIENT"]
 
     changed = 0
     now = _iso(_utcnow())
@@ -132,6 +193,12 @@ def vocab_enrich_all():
                 "image_url": img.fetch(c["word"]) if (current_app.config["G_CSE_KEY"] and current_app.config["G_CSE_CX"]) else None,
                 "status": "enrich", "updated_at": now
             })
+            if current_app.config["OPENAI_KEY"]:
+                audio_dir = __import__("os").path.join(current_app.config["CARDS_DIR"], "audio")
+                filename = f"{c['id']}.mp3"
+                full = __import__("os").path.join(audio_dir, filename)
+                if tts.synthesize_to_file(c["word"], full):
+                    c["audio_url"] = f"/data/cards/audio/{filename}"
             changed += 1
 
             similars = llm.generate_similar_or_confusables(c["word"]) if current_app.config["OPENAI_KEY"] else []
@@ -139,12 +206,20 @@ def vocab_enrich_all():
                 if not any(x["word"].lower() == s.lower() for x in data["cards"]):
                     desc2 = llm.describe_word(s) if current_app.config["OPENAI_KEY"] else {"pos":"", "meaning_vi":"", "usage":"", "phonetic":""}
                     img2 = img.fetch(s) if (current_app.config["G_CSE_KEY"] and current_app.config["G_CSE_CX"]) else None
+                    add_id = str(uuid.uuid4())
+                    audio_url = None
+                    if current_app.config["OPENAI_KEY"]:
+                        audio_dir = __import__("os").path.join(current_app.config["CARDS_DIR"], "audio")
+                        filename = f"{add_id}.mp3"
+                        full = __import__("os").path.join(audio_dir, filename)
+                        if tts.synthesize_to_file(s, full):
+                            audio_url = f"/data/cards/audio/{filename}"
                     data["cards"].append({
-                        "id": str(uuid.uuid4()), "word": s.capitalize(),
+                        "id": add_id, "word": s.capitalize(),
                         "status": "additional", "origin": "auto_additional",
                         "pos": desc2.get("pos",""), "meaning_vi": desc2.get("meaning_vi",""),
                         "usage": desc2.get("usage",""), "phonetic": desc2.get("phonetic",""),
-                        "image_url": img2,
+                        "image_url": img2, "audio_url": audio_url,
                         "created_at": now, "updated_at": now,
                         "memory_label": "", "stats": {"correct": 0, "wrong": 0}
                     })
@@ -153,17 +228,28 @@ def vocab_enrich_all():
 
 
 # ---------- BÀI TEST ----------
-@bp.get("/test")
-def test_page():
+#
+# Các hàm xử lý route dưới đây trước đây được đặt tên bắt đầu bằng
+# ``test_*``.  Điều này vô tình khiến ``pytest`` hiểu đây là các testcase
+# và cố gắng chạy chúng mà không có ngữ cảnh Flask thích hợp, dẫn tới lỗi
+# "Working outside of application/request context" khi chạy kiểm thử.
+#
+# Đổi tên các hàm để tránh bị thu thập bởi ``pytest``.  Để giữ nguyên tên
+# endpoint (phục vụ ``url_for`` nếu được dùng ở nơi khác) chúng ta chỉ định
+# tham số ``endpoint`` trong decorator.
+
+@bp.get("/test", endpoint="test_page")
+def vocab_test_page():
     "Trang bắt đầu bài test ôn từ (templates/test.html)."
     return render_template("test.html", title="Test từ vựng")
 
-@bp.post("/tests/start")
-def tests_start():
+@bp.post("/tests/start", endpoint="tests_start")
+def vocab_tests_start():
     "Chọn 10 từ theo tỉ lệ 5/30/65, sinh bài tập (MCQ + gõ từ)."
     data = load_cards()
     picked = WordSampler.sample_for_test(data["cards"], k=10)
     items = ExerciseBuilder.build_for_words(picked, data["cards"])
+    __import__('random').shuffle(items)
 
     session_id = str(uuid.uuid4())
     sess_path = __import__("os").path.join(current_app.config["TESTS_DIR"], f"{session_id}.json")
@@ -173,8 +259,8 @@ def tests_start():
 
     return jsonify({"session_id": session_id, "picked_words": [x["word"] for x in picked], "items": items})
 
-@bp.post("/tests/finalize")
-def tests_finalize():
+@bp.post("/tests/finalize", endpoint="tests_finalize")
+def vocab_tests_finalize():
     """
     Chốt phiên test (DEMO):
       - hiện tại gắn nhãn LTM cho các từ đã pick (bạn có thể nâng cấp logic wrong-only/nhãn sau).

--- a/services/test_generator.py
+++ b/services/test_generator.py
@@ -33,7 +33,8 @@ class ExerciseBuilder:
             "word": word["word"],
             "prompt_vi": word.get("meaning_vi","(no meaning)"),
             "options": options,
-            "answer": word["word"]
+            "answer": word["word"],
+            "audio_url": word.get("audio_url")
         }
 
     @staticmethod
@@ -42,11 +43,20 @@ class ExerciseBuilder:
             "type": "type_from_meaning",
             "word": word["word"],
             "prompt_vi": word.get("meaning_vi","(no meaning)"),
+            "audio_url": word.get("audio_url")
+        }
+
+    @staticmethod
+    def build_audio_to_en(word: Dict) -> Dict:
+        return {
+            "type": "audio_to_en",
+            "word": word["word"],
+            "audio_url": word.get("audio_url")
         }
 
     @staticmethod
     def build_for_words(words: List[Dict], all_words: List[Dict]) -> List[Dict]:
-        # For each word, create 2 exercises: vi2en_mcq and type_from_meaning
+        # For each word, create exercises: vi2en_mcq, type_from_meaning and audio_to_en
         all_lex = [w["word"] for w in all_words]
         items = []
         for w in words:
@@ -55,4 +65,7 @@ class ExerciseBuilder:
             random.shuffle(others)
             items.append(ExerciseBuilder.build_vi2en_mcq(w, others))
             items.append(ExerciseBuilder.build_type_from_meaning(w))
+            if w.get("audio_url"):
+                items.append(ExerciseBuilder.build_audio_to_en(w))
+        random.shuffle(items)
         return items

--- a/services/tts_service.py
+++ b/services/tts_service.py
@@ -1,0 +1,32 @@
+import os, random
+from typing import Optional
+import requests
+
+class TTSClient:
+    """Simple wrapper around OpenAI Text-to-Speech API.
+
+    If api_key is missing, synthesize_to_file will return False
+    without performing network calls."""
+    def __init__(self, api_key: Optional[str]=None, model: str="gpt-4o-mini-tts"):
+        self.api_key = api_key
+        self.model = model
+        self.voices = ["alloy", "verse", "lumen", "orion"]
+
+    def _headers(self):
+        return {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
+
+    def synthesize_to_file(self, text: str, out_path: str) -> bool:
+        if not self.api_key:
+            return False
+        voice = random.choice(self.voices)
+        payload = {"model": self.model, "voice": voice, "input": text}
+        url = "https://api.openai.com/v1/audio/speech"
+        try:
+            r = requests.post(url, headers=self._headers(), json=payload, timeout=60)
+            r.raise_for_status()
+            os.makedirs(os.path.dirname(out_path), exist_ok=True)
+            with open(out_path, "wb") as f:
+                f.write(r.content)
+            return True
+        except Exception:
+            return False

--- a/static/js/test.js
+++ b/static/js/test.js
@@ -37,6 +37,7 @@ function renderItems(items){
           $('#fb-'+idx).textContent = correct ? 'Đúng' : 'Sai';
           if(!correct) wrongIndices.add(idx);
           else wrongIndices.delete(idx);
+          playAudio(it.audio_url);
         });
         opts.appendChild(btn);
         opts.appendChild(document.createTextNode(' '));
@@ -54,6 +55,23 @@ function renderItems(items){
         $('#fb-'+idx).textContent = correct ? 'Đúng' : 'Sai (đáp án: '+it.word+')';
         if(!correct) wrongIndices.add(idx);
         else wrongIndices.delete(idx);
+        playAudio(it.audio_url);
+      });
+    }else if(it.type === 'audio_to_en'){
+      card.innerHTML = `
+        <div><b>[Nghe]</b> Nghe audio và gõ từ tiếng Anh</div>
+        <button class="btn secondary" id="play-${idx}">Phát</button>
+        <input type="text" id="in-${idx}"/>
+        <button class="btn secondary" id="chk-${idx}">Kiểm tra</button>
+        <div id="fb-${idx}" class="small mono"></div>
+      `;
+      card.querySelector('#play-'+idx).addEventListener('click', ()=> playAudio(it.audio_url));
+      card.querySelector('#chk-'+idx).addEventListener('click', ()=>{
+        const v = card.querySelector('#in-'+idx).value.trim();
+        const correct = (v.toLowerCase() === it.word.toLowerCase());
+        $('#fb-'+idx).textContent = correct ? 'Đúng' : 'Sai (đáp án: '+it.word+')';
+        if(!correct) wrongIndices.add(idx); else wrongIndices.delete(idx);
+        playAudio(it.audio_url);
       });
     }else{
       card.textContent = '(Bài tập khác sẽ được bổ sung)';
@@ -86,4 +104,12 @@ async function finalizeTest(){
   session.picked_words.forEach(w => labelSummary.LTM++);
   const res = await postJSON('/tests/finalize', { session_id: session.session_id, label_summary: labelSummary });
   alert('Đã cập nhật nhãn ghi nhớ. Tóm tắt: ' + JSON.stringify(labelSummary));
+}
+
+function playAudio(url){
+  if(!url) return;
+  try{
+    const a = new Audio(url);
+    a.play();
+  }catch(e){/* ignore */}
 }

--- a/static/js/vocab.js
+++ b/static/js/vocab.js
@@ -130,10 +130,12 @@ async function showDetail(id, scrollIntoView){
     <div style="margin:8px 0;">
       <img src="${c.image_url}" alt="${c.word}" style="max-width:100%; border-radius:10px;">
     </div>` : '';
+  const audio = c.audio_url ? `<audio controls src="${c.audio_url}" style="width:100%; margin-top:8px;"></audio>` : '';
 
   $('#detailBody').innerHTML = `
     <div style="font-size:22px; font-weight:700;">${c.word || ''}</div>
     ${img}
+    ${audio}
     <div style="margin-top:6px;"><b>Phonetic:</b> ${c.phonetic || '—'}</div>
     <div><b>POS:</b> ${c.pos || '—'}</div>
     <div><b>Nghĩa (VI):</b> ${c.meaning_vi || '—'}</div>
@@ -141,11 +143,14 @@ async function showDetail(id, scrollIntoView){
     <div class="small mono" style="margin-top:8px;">
       Status: ${c.status || '—'} · Origin: ${c.origin || '—'} · Memory: ${c.memory_label || '—'}
     </div>
+    <button class="btn" id="btnFillMissing" style="margin-top:8px;">Bổ sung thiếu</button>
   `;
 
   if(scrollIntoView){
     document.getElementById('detailPanel').scrollIntoView({behavior:'smooth', block:'start'});
   }
+
+  $('#btnFillMissing').addEventListener('click', ()=> fillMissing(c.id));
 }
 
 /** ======== Actions ======== */
@@ -163,5 +168,17 @@ async function onEnrichAll(){
   }finally{
     btn.disabled = false;
     btn.textContent = 'Enrich All';
+  }
+}
+
+async function fillMissing(id){
+  try{
+    const res = await postJSON('/vocab/fill_missing/'+id, {});
+    alert(res.updated ? 'Đã bổ sung.' : 'Không có gì để bổ sung.');
+    await loadSummary();
+    applyFiltersAndRender();
+    showDetail(id, false);
+  }catch(e){
+    alert('Lỗi: '+e.message);
   }
 }

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -12,6 +12,7 @@ def bootstrap_data_dirs(app):
     """
     for k in ("LESSON_DIR", "CARDS_DIR", "TESTS_DIR"):
         os.makedirs(app.config[k], exist_ok=True)
+    os.makedirs(os.path.join(app.config["CARDS_DIR"], "audio"), exist_ok=True)
     # cards.json
     cp = os.path.join(app.config["CARDS_DIR"], "cards.json")
     if not os.path.isfile(cp):


### PR DESCRIPTION
## Summary
- integrate OpenAI TTS service and store audio for each vocabulary card
- add button to fill missing vocab details and expose audio in review UI
- expand tests with audio exercises and shuffle order

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aaa75d71a8833391c88134c8d67992